### PR TITLE
Add Amiga games quiz script

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Remember to always commit your local changes or stash them before pulling update
 - **`pnpm run typegen`**: Generates TypeScript types using Wrangler.
 - **`pnpm run deploy`**: Deploys the project to Cloudflare Pages.
 - **`pnpm run lint:fix`**: Automatically fixes linting issues.
+- **`pnpm run amiga-quiz`**: Startet ein kleines Quiz über klassische Amiga-Spiele im Terminal.
 
 ---
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -218,6 +218,7 @@ When you add a new model to the MODEL_LIST array, it will immediately be availab
 - `pnpm run typecheck`: Runs TypeScript type checking.
 - `pnpm run typegen`: Generates TypeScript types using Wrangler.
 - `pnpm run deploy`: Builds the project and deploys it to Cloudflare Pages.
+- `pnpm run amiga-quiz`: Starts a small quiz about classic Amiga games in the terminal.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "typecheck": "tsc",
     "typegen": "wrangler types",
     "preview": "pnpm run build && pnpm run start",
-    "prepare": "husky"
+    "prepare": "husky",
+    "amiga-quiz": "node scripts/amiga-quiz.js"
   },
   "engines": {
     "node": ">=18.18.0"

--- a/scripts/amiga-quiz.js
+++ b/scripts/amiga-quiz.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+const questions = [
+  {
+    question: 'Wie heißt das Amiga-Spiel, in dem der Charakter Guybrush Threepwood die Hauptrolle spielt?',
+    answer: 'The Secret of Monkey Island',
+  },
+  {
+    question: 'Welches Rennspiel von Psygnosis aus dem Jahr 1991 war für seinen Looping-Bug bekannt?',
+    answer: 'Formula One Grand Prix',
+  },
+  {
+    question: 'In welchem Spiel kämpft der Spieler als Turrican gegen den Maschinenherrscher Morgul?',
+    answer: 'Turrican',
+  },
+  {
+    question: 'Welches Amiga-Spiel basiert auf der Filmreihe um Ellen Ripley und beinhaltet Facehuggers?',
+    answer: 'Alien Breed',
+  },
+  {
+    question: 'Wie heißt der Hund, der im Spiel “Another World” den Helden kurzzeitig begleitet?',
+    answer: 'Frogsdog',
+  },
+];
+
+const rl = readline.createInterface({ input, output });
+let score = 0;
+
+for (const { question, answer } of questions) {
+  const user = await rl.question(`${question}\n> `);
+  if (user.trim().toLowerCase() === answer.toLowerCase()) {
+    console.log('Richtig!');
+    score++;
+  } else {
+    console.log(`Falsch! Richtige Antwort: ${answer}`);
+  }
+  console.log('');
+}
+
+console.log(`Du hast ${score} von ${questions.length} Fragen richtig beantwortet.`);
+rl.close();


### PR DESCRIPTION
## Summary
- add interactive Amiga games quiz script
- document new CLI script in README and docs

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6895e09a0f088324bca63b9e54014580